### PR TITLE
Add env example for circle miniapp

### DIFF
--- a/aurum-circle-miniapp/.env.example
+++ b/aurum-circle-miniapp/.env.example
@@ -1,0 +1,16 @@
+# World ID Configuration
+WORLD_ID_APP_ID=app_placeholder        # Replace with your World ID App ID in production
+WORLD_ID_ACTION=verify-human           # Default action; update if needed
+
+# Redis Configuration
+REDIS_URL=redis://localhost:6379       # Use your production Redis URL
+
+# Qdrant Configuration
+QDRANT_HOST=localhost                  # Qdrant host; set to production host
+QDRANT_PORT=6333                       # Qdrant port; set to production port
+
+# AI Services (Optional)
+AI_API_KEY=your_ai_service_key         # Required in production for AI endpoints
+
+# Node Environment
+NODE_ENV=development                   # Change to 'production' in production


### PR DESCRIPTION
## Summary
- add `.env.example` for Aurum Circle with placeholder values and production guidance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx -y vitest run` *(fails: Cannot find module 'vitest/config')*
- `npm run lint` *(fails: Failed to load config "next/typescript" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_689617adb194833092f458bb7f92ebe2