### PR TITLE
feat: add env example for ml face score api

### DIFF
--- a/aurum-circle-miniapp/.gitignore
+++ b/aurum-circle-miniapp/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!**/.env.example
 
 # ML Models (too large for git - download separately)
 public/models/arcface/

--- a/aurum-circle-miniapp/ml-face-score-api/.env.example
+++ b/aurum-circle-miniapp/ml-face-score-api/.env.example
@@ -1,0 +1,16 @@
+# Redis Configuration
+REDIS_URL=redis://localhost:6379
+
+# Server Configuration
+PORT=3000
+NODE_ENV=development
+
+# Rust ML Services Configuration
+FACE_DETECTION_SERVICE=http://localhost:8001
+FACE_EMBEDDING_SERVICE=http://localhost:8002
+ML_SERVICE_TIMEOUT=5000
+USE_REAL_ML=true
+
+# Fallback Configuration
+FALLBACK_TO_SIMULATED=true
+SIMULATED_ML_THRESHOLD=0.7

--- a/aurum-circle-miniapp/ml-face-score-api/.gitignore
+++ b/aurum-circle-miniapp/ml-face-score-api/.gitignore
@@ -6,3 +6,4 @@ logs/
 
 # environment files
 .env*
+!.env.example


### PR DESCRIPTION
## Summary
- add .env.example for ml-face-score-api with default development values
- allow committing env example files

## Testing
- `npm test` (fails: jest: not found)
- `npm install` (fails: ENETUNREACH when installing onnxruntime-node)


------
https://chatgpt.com/codex/tasks/task_e_68961a5ca9c883308060c8a5dcda9ace