### PR TITLE
Add initial CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: aurum-circle-miniapp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: aurum-circle-miniapp/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  ml-api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "ML API tests not yet implemented"
+        # TODO: Add ML API tests when available
+
+  rust-services:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Rust service tests not yet implemented"
+        # TODO: Add Rust service tests when available


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running `npm ci`, `npm run lint`, and `npm test`
- scaffold jobs for ML API and Rust services

## Testing
- `npm ci`
- `npm run lint` *(fails: Failed to load config "next/typescript" to extend from.)*
- `npm test` *(fails: Missing script: "test".)*

------
https://chatgpt.com/codex/tasks/task_e_68961a5df44c8330b83d8d287fdb8597