### PR TITLE
Use repository-relative paths for ML service builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ This repository contains the production configuration and components for the Aur
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+
+## Running with Docker Compose
+
+To start the full application stack, ensure Docker is installed and then run:
+
+```bash
+cd aurum-circle-miniapp
+docker-compose up --build
+```
+
+After the services finish building, the front end is available at
+[`http://localhost:3000`](http://localhost:3000).

--- a/aurum-circle-miniapp/docker-compose.dev.yml
+++ b/aurum-circle-miniapp/docker-compose.dev.yml
@@ -99,7 +99,7 @@ services:
   # Rust ML Services (development)
   face-detection-service:
     build:
-      context: /Users/poomcryptoman/Arisium/aurum-circle-new/aurum-ml-services
+      context: ../aurum-ml-services
       dockerfile: face-detection/Dockerfile.dev
     ports:
       - "8001:8001"
@@ -116,7 +116,7 @@ services:
 
   face-embedding-service:
     build:
-      context: /Users/poomcryptoman/Arisium/aurum-circle-new/aurum-ml-services
+      context: ../aurum-ml-services
       dockerfile: face-embedding/Dockerfile.dev
     ports:
       - "8002:8002"

--- a/aurum-circle-miniapp/docker-compose.yml
+++ b/aurum-circle-miniapp/docker-compose.yml
@@ -184,7 +184,7 @@ services:
   # Rust ML Services
   face-detection-service:
     build:
-      context: /Users/poomcryptoman/Arisium/aurum-circle-new/aurum-ml-services
+      context: ../aurum-ml-services
       dockerfile: face-detection/Dockerfile
     ports:
       - "8001:8001"
@@ -208,7 +208,7 @@ services:
 
   face-embedding-service:
     build:
-      context: /Users/poomcryptoman/Arisium/aurum-circle-new/aurum-ml-services
+      context: ../aurum-ml-services
       dockerfile: face-embedding/Dockerfile
     ports:
       - "8002:8002"


### PR DESCRIPTION
## Summary
- replace absolute ML service build contexts with repo-relative paths
- document how to bring up the stack with `docker-compose up --build`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_689628b5892c8330ab36ceb7075a12c5