### PR TITLE
Update Nginx proxies for app and ML API

### DIFF
--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -36,9 +36,9 @@ server {
     # limit_req_zone $binary_remote_addr zone=api:10m rate=100r/m;
     # limit_req zone=api burst=20 nodelay;
 
-    # Proxy to Go API Gateway for /api/* routes
+    # Proxy Next.js API routes directly to the app
     location /api/ {
-        proxy_pass http://api-gateway:8081;
+        proxy_pass http://app:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -51,8 +51,8 @@ server {
         proxy_connect_timeout 60s;
     }
 
-    # Proxy to ML API for /ml-api/* routes (or specific paths if API Gateway handles /api/ml/*)
-    # This is a direct route for ML API, adjust if API Gateway handles all ML requests
+    # Proxy to ML API for /ml-api/* routes
+    # Trailing slash on proxy_pass preserves the path after /ml-api/
     location /ml-api/ {
         proxy_pass http://ml-api:3000/; # ML API listens on 3000 internally
         proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- Proxy `/api/` routes directly to the Next.js `app` service
- Keep `/ml-api/` proxy to `ml-api:3000` and clarify path handling

## Testing
- `docker compose --version` *(command not found)*
- `nginx -t -c /workspace/aurum-miniapp-prod/nginx/nginx.conf` *(host not found in upstream "app:3000")*

------
https://chatgpt.com/codex/tasks/task_e_68963020714483308507831e46e25bc7