### PR TITLE
Expose HTTPS ports in Nginx Dockerfile

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,8 +6,11 @@ RUN rm /etc/nginx/conf.d/default.conf
 # Copy custom main nginx configuration
 COPY nginx.conf /etc/nginx/nginx.conf
 
-# Expose port 80
-EXPOSE 80
+# Copy additional configuration files
+COPY conf /etc/nginx/conf.d
+
+# Expose HTTP and HTTPS ports
+EXPOSE 80 443
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- copy `conf` directory into Nginx image
- expose both HTTP (80) and HTTPS (443) ports

## Testing
- `npm install --no-package-lock` *(failed: ENETUNREACH)*
- `docker-compose build nginx` *(failed: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_689630233fcc8330aa1a045630873e9a