### PR TITLE
docs: streamline deployment without api gateway

### DIFF
--- a/ANALYZE_AND_FIX_NGINX_PROXY.md
+++ b/ANALYZE_AND_FIX_NGINX_PROXY.md
@@ -31,7 +31,7 @@ The goal is for Nginx (listening on port 80) to be the only point of access for 
   - **`listen` Directives**: Ensure Nginx listens on `80` (and potentially `443` if SSL is configured, though not indicated yet).
   - **`server_name`**: Should be appropriate (e.g., `localhost` or a domain).
   - **`location` Blocks**:
-    - Check if all necessary paths are covered (e.g., `/`, `/api/ml/`, `/api/face-detection/`, etc.).
+    - Check if all necessary paths are covered (e.g., `/`, `/ml-api/`, `/api/face-detection/`, etc.).
     - Verify `proxy_pass` directives correctly point to the defined upstreams (e.g., `http://app;`, `http://ml-api;`).
     - Ensure proxy headers (`Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`, `Upgrade`, `Connection`) are correctly set.
   - **Default Proxy Behavior**: Ensure there's a default `location /` or `location / { ... }` to catch requests not matching other specific paths.
@@ -100,7 +100,7 @@ The goal is for Nginx (listening on port 80) to be the only point of access for 
                 # ... other proxy headers
             }
 
-            location /api/ml/ {
+            location /ml-api/ {
                 proxy_pass http://ml_api; # Use upstream name
                 # ... other proxy headers
             }
@@ -118,7 +118,7 @@ The goal is for Nginx (listening on port 80) to be the only point of access for 
     - Test access:
       - `http://<your-server-ip>:80` should work and serve the Next.js app.
       - `http://<your-server-ip>:3000` should **not** work (or should be blocked by firewall/Nginx if it somehow maps).
-      - API calls via Nginx (e.g., `http://<your-server-ip>:80/api/ml/...`) should work.
+      - API calls via Nginx (e.g., `http://<your-server-ip>:80/ml-api/...`) should work.
 5.  **Commit and Push Changes**:
     - Once verified, commit all configuration changes.
 

--- a/ANALYZE_AND_FIX_NGINX_PROXY_EXPANDED.md
+++ b/ANALYZE_AND_FIX_NGINX_PROXY_EXPANDED.md
@@ -41,7 +41,7 @@ The goal is for Nginx (listening on port 80) to be the only point of access for 
   - **`listen` Directives**: Ensure Nginx listens only on `80` (and `443` if SSL is configured).
   - **`server_name`**: Should be appropriate (e.g., `localhost` or a domain).
   - **`location` Blocks**:
-    - **Comprehensive Coverage**: Meticulously check if all necessary application paths are covered (e.g., `/`, `/api/ml/`, `/api/face-detection/`, `/api/face-embedding/`, static file paths, API health checks).
+    - **Comprehensive Coverage**: Meticulously check if all necessary application paths are covered (e.g., `/`, `/ml-api/`, `/api/face-detection/`, `/api/face-embedding/`, static file paths, API health checks).
     - **`proxy_pass` Directives**: Verify `proxy_pass` directives correctly point to the defined upstreams (e.g., `http://app;`, `http://ml_api;`). Ensure trailing slashes are handled correctly.
     - **Proxy Headers**: Ensure all necessary proxy headers (`Host`, `X-Real-IP`, `X-Forwarded-For`, `X-Forwarded-Proto`, `Upgrade`, `Connection`, `X-Forwarded-Host`) are correctly set.
   - **Default Proxy Behavior**: Ensure there's a default `location /` or `location / { ... }` to catch requests not matching other specific paths.
@@ -162,7 +162,7 @@ Based on the analysis, refactor the Nginx setup to a more standard and maintaina
       }
 
       # ML API proxy
-      location /api/ml/ {
+      location /ml-api/ {
           proxy_pass http://ml_api;
           proxy_http_version 1.1;
           proxy_set_header Upgrade $http_upgrade;
@@ -239,7 +239,7 @@ Based on the analysis, refactor the Nginx setup to a more standard and maintaina
   - `curl -I http://<your-server-ip>:3000` -> Should return Connection Refused or similar.
   - `curl -I http://<your-server-ip>:3001` -> Should return Connection Refused or similar.
 - **API Access via Nginx**:
-  - `curl -I http://<your-server-ip>:80/api/ml/...` -> Should work, proxied to `ml-api`.
+  - `curl -I http://<your-server-ip>:80/ml-api/...` -> Should work, proxied to `ml-api`.
   - `curl -I http://<your-server-ip>:80/api/health` -> Should work, proxied to `app`.
 - **Nginx Logs**: `docker logs aurum-miniapp-prod-nginx-1` - Check for access patterns and errors.
 - **Application Logs**: `docker logs aurum-miniapp-prod-app-1` and `docker logs aurum-miniapp-prod-ml-api-1` - Check for any errors related to proxying, URLs, or connections.

--- a/NEXT_ACTIONS_NGINX_FIX.md
+++ b/NEXT_ACTIONS_NGINX_FIX.md
@@ -45,7 +45,7 @@ The most critical step is to address the Nginx configuration structure identifie
 - **Action**: Perform the tests outlined in **Phase 3.2** of the expanded task.
   - Test frontend access via Nginx (`http://<server-ip>:80`).
   - Attempt direct access to app and ml-api ports (`http://<server-ip>:3000`, `http://<server-ip>:3001`) - these should fail.
-  - Test API access via Nginx (`http://<server-ip>:80/api/ml/...`).
+  - Test API access via Nginx (`http://<server-ip>:80/ml-api/...`).
 - **Reasoning**: To confirm Nginx is routing correctly and is the sole entry point.
 - **Est. Time**: 1 hour
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ This deployment includes:
 - Qdrant vector database
 - Nginx reverse proxy (running in Docker)
 
+## Architecture
+
+Nginx acts as the single entry point for the deployment:
+
+- Requests to `/` and `/api/*` are forwarded to the Next.js application which handles UI and API routes internally.
+- Requests to `/ml-api/*` are proxied to the ML Face Scoring API service.
+
+Both services run on the same Docker network and communicate directly without an API gateway.
+
 ## Prerequisites
 
 - Docker and Docker Compose installed
@@ -40,7 +49,7 @@ This deployment includes:
 
 4. The application will be available at:
    - Main app: http://localhost
-   - ML API: http://localhost/api/ml/
+   - ML API: http://localhost/ml-api/
    - Direct app access: http://localhost:3000
    - Direct ML API access: http://localhost:3001
 
@@ -50,8 +59,8 @@ This deployment includes:
 
 Before deploying, update the environment variables in the service directories:
 
-- `miniapp/aurum-circle-miniapp/.env.local`
-- `miniapp/ml-face-score-api/.env.local`
+- `miniapp/aurum-circle-miniapp/.env.local` – set `ML_API_URL` to the internal ML API address (e.g., `http://ml-api:3000` or `http://localhost/ml-api`).
+- `miniapp/ml-face-score-api/.env.local` – configure service settings such as `REDIS_URL`.
 
 ### Nginx Configuration
 
@@ -76,7 +85,7 @@ For production deployment with HTTPS, add your SSL certificates to `nginx/certs/
 
 ## Networks
 
-All services are connected through the `aurum-network` bridge network.
+All services share the `aurum-network` bridge network. Nginx is the only exposed container and proxies traffic to the Next.js app and the ML API service.
 
 ## Troubleshooting
 

--- a/miniapp/aurum-circle-miniapp/CURRENT_ARCHITECTURE.md
+++ b/miniapp/aurum-circle-miniapp/CURRENT_ARCHITECTURE.md
@@ -79,10 +79,10 @@ Percentile Calculation → Vibe Clustering → Score Return
 
 ### ML API Service Endpoints
 
-- `POST /api/score` - Submit image for processing
-- `GET /api/result/:jobId` - Get processing results
-- `GET /api/status` - Service status
-- `GET /api/ml-status` - ML model status
+- `POST /ml-api/api/score` - Submit image for processing
+- `GET /ml-api/api/result/:jobId` - Get processing results
+- `GET /ml-api/api/status` - Service status
+- `GET /ml-api/api/ml-status` - ML model status
 
 ## Current ML Components (Simulated)
 

--- a/miniapp/aurum-circle-miniapp/ml-face-score-api/DEPLOYMENT.md
+++ b/miniapp/aurum-circle-miniapp/ml-face-score-api/DEPLOYMENT.md
@@ -39,13 +39,13 @@ This guide explains how to deploy the ML Model API for public access.
 
 ## API Endpoints
 
-Once deployed, the following endpoints will be available:
+Once deployed, the following endpoints will be available. When accessed through the main Nginx proxy, each route is prefixed with `/ml-api`:
 
-- `POST /api/score` - Submit an image for scoring
-- `GET /api/status/:jobId` - Check job status
-- `GET /api/result/:jobId` - Get job result
-- `GET /api/ml-status` - Check ML model status
-- `GET /health` - Health check endpoint
+- `POST /ml-api/api/score` - Submit an image for scoring
+- `GET /ml-api/api/status/:jobId` - Check job status
+- `GET /ml-api/api/result/:jobId` - Get job result
+- `GET /ml-api/api/ml-status` - Check ML model status
+- `GET /ml-api/health` - Health check endpoint
 
 ## Scaling
 


### PR DESCRIPTION
## Summary
- document Nginx as the sole entry point routing `/` and `/api/*` to Next.js and `/ml-api/*` to the ML API
- update endpoint examples and environment variable guidance to use the `/ml-api` prefix
- describe network topology for the gateway-free design and adjust Nginx guidance accordingly

## Testing
- `npm install` *(failed: ENETUNREACH)*
- `npm test` *(failed: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689630234a6883308e2c45cec354e41d