### PR TITLE
Install dev deps in miniapp Dockerfile and prune after build

### DIFF
--- a/miniapp/aurum-circle-miniapp/Dockerfile
+++ b/miniapp/aurum-circle-miniapp/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies (including dev dependencies for build)
-RUN npm ci --only=production --ignore-scripts
+RUN npm ci
 
 # Copy the rest of the application code
 COPY . .
@@ -21,6 +21,7 @@ RUN npm run download-models
 
 # Build the Next.js application with standalone output
 RUN npm run build
+RUN npm prune --omit=dev
 
 # Production stage
 FROM node:20-alpine AS runner


### PR DESCRIPTION
## Summary
- install dev dependencies during Docker build for aurum-circle-miniapp
- prune dev packages after build to slim final image

## Testing
- `docker build --no-cache -t aurum-circle-miniapp-test miniapp/aurum-circle-miniapp` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `npm ls eslint`

------
https://chatgpt.com/codex/tasks/task_e_68963948fd0c83309f098178b4a4e1a6