### PR TITLE
fix invite validation route params

### DIFF
--- a/miniapp/aurum-circle-miniapp/src/app/api/invites/validate/[code]/route.ts
+++ b/miniapp/aurum-circle-miniapp/src/app/api/invites/validate/[code]/route.ts
@@ -3,10 +3,10 @@ import prisma from '@/lib/prisma'
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { code: string } }
+  { params }: { params: Promise<{ code: string }> }
 ) {
   try {
-    const { code } = params
+    const { code } = await params
 
     if (!code) {
       return NextResponse.json({ success: false, message: 'Invite code is required' }, { status: 400 })


### PR DESCRIPTION
## Summary
- update invite validation route to accept async `params`

## Testing
- `npm run build` (fails: Unexpected any. Specify a different type.)

------
https://chatgpt.com/codex/tasks/task_e_6896394ef9a88330bfc3bff9bdb9b76c