### PR TITLE
fix: copy scripts before installing dependencies

### DIFF
--- a/miniapp/aurum-circle-miniapp/Dockerfile
+++ b/miniapp/aurum-circle-miniapp/Dockerfile
@@ -10,6 +10,9 @@ WORKDIR /app
 # Copy package.json and package-lock.json
 COPY package*.json ./
 
+# Ensure scripts are available for lifecycle hooks
+COPY scripts ./scripts
+
 # Install dependencies (including dev dependencies for build)
 RUN npm ci
 


### PR DESCRIPTION
## Summary
- copy scripts directory before running npm ci so lifecycle hooks can execute

## Testing
- `npm test` (fails: Missing script: "test")
- `npm ci --no-progress` (succeeds, runs download-models)
- `docker build miniapp/aurum-circle-miniapp -f miniapp/aurum-circle-miniapp/Dockerfile --no-cache` (fails: Cannot connect to the Docker daemon)


------
https://chatgpt.com/codex/tasks/task_e_68976ed56b3483309db8ab84fbad97f2