### PR TITLE
refactor: use type alias for input props

### DIFF
--- a/miniapp/aurum-circle-miniapp/src/components/ui/input.tsx
+++ b/miniapp/aurum-circle-miniapp/src/components/ui/input.tsx
@@ -1,8 +1,7 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- replace empty InputProps interface with type alias

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and related lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68977689a0788330a55b488a1e463638