### PR TITLE
Remove unused variable and escape apostrophe in SwipeStack

### DIFF
--- a/miniapp/aurum-circle-miniapp/src/components/discovery/SwipeStack.tsx
+++ b/miniapp/aurum-circle-miniapp/src/components/discovery/SwipeStack.tsx
@@ -78,7 +78,6 @@ export function SwipeStack({ profiles, onSwipe, onSignal, className = "" }: Swip
 
   const handleDragEnd = (event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
     const threshold = 150
-    const velocity = Math.abs(info.velocity.x) > Math.abs(info.velocity.y) ? info.velocity.x : info.velocity.y
     const isHorizontal = Math.abs(info.offset.x) > Math.abs(info.offset.y)
     
     let direction: 'left' | 'right' | 'up' | null = null
@@ -160,7 +159,7 @@ export function SwipeStack({ profiles, onSwipe, onSignal, className = "" }: Swip
             <span className="text-4xl">✨</span>
           </div>
           <h2 className="text-2xl font-bold text-text-primary mb-2">
-            You've explored everyone!
+            You&apos;ve explored everyone!
           </h2>
           <p className="text-text-muted mb-6">
             Check back later for new members joining Aurum Circle


### PR DESCRIPTION
## Summary
- remove unused velocity variable from drag handler
- escape apostrophe in empty-profiles message

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors in existing files)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68977689c930833083647e50a5a4a1b4