### PR TITLE
Remove unused mlModelIntegration import

### DIFF
--- a/miniapp/aurum-circle-miniapp/src/lib/image-processing-queue.ts
+++ b/miniapp/aurum-circle-miniapp/src/lib/image-processing-queue.ts
@@ -6,7 +6,6 @@
 import { Queue, Worker, Job } from "bullmq";
 import Redis from "ioredis";
 import { ProcessedFace } from "@/lib/face-embeddings";
-import { mlModelIntegration } from "@/lib/ml-models/model-integration";
 
 // Initialize Redis connection
 const redisConnection = new Redis(


### PR DESCRIPTION
## Summary
- remove unused mlModelIntegration import from image processing queue

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, and react/no-unescaped-entities across multiple files)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897768b2d608330a9d6d3bf52071365