### PR TITLE
chore: remove unused eslint disable comment

### DIFF
--- a/miniapp/aurum-circle-miniapp/src/lib/minikit.ts
+++ b/miniapp/aurum-circle-miniapp/src/lib/minikit.ts
@@ -1,6 +1,5 @@
 // This file is commented out due to TypeScript/ESLint issues with @worldcoin/minikit-js
 // It will be re-enabled and properly typed in a separate task.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
 /*
 import { MiniKit } from "@worldcoin/minikit-js";
 


### PR DESCRIPTION
## Summary
- remove unnecessary ESLint disable comment from MiniKit helper

## Testing
- `npm test` *(fails: jest: not found; attempted installation but network unreachable)*
- `npm run lint` *(fails: multiple @typescript-eslint/no-explicit-any warnings)
- `npm test` *(miniapp/aurum-circle-miniapp: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6897768be1b8833088e24fef5e1769c2