### PR TITLE
chore: clean up lint overrides

### DIFF
--- a/miniapp/aurum-circle-miniapp/src/lib/vibe-clustering.ts
+++ b/miniapp/aurum-circle-miniapp/src/lib/vibe-clustering.ts
@@ -133,7 +133,6 @@ export class VibeClusterer {
   /**
    * Extract vibe-relevant features from full embedding
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private extractVibeFeatures(
     embedding: number[],
     _face: ProcessedFace


### PR DESCRIPTION
## Summary
- remove leftover eslint-disable comment before `extractVibeFeatures`

## Testing
- `npm run lint` *(fails: npm: No such file or directory)*
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897768e02a483308beed3dce6f8df6d