### PR TITLE
chore: expose redis on port 6380

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -94,7 +94,7 @@ services:
   redis:
     image: redis:latest
     ports:
-      - "6379:6379" # Expose for direct access if needed
+      - "6380:6379" # Expose for direct access if needed
     volumes:
       - redis_data:/data
     restart: unless-stopped

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -106,7 +106,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379" # Expose for direct access if needed
+      - "6380:6379" # Expose for direct access if needed
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes


### PR DESCRIPTION
## Summary
- expose Redis on host port 6380 while keeping container on 6379
- confirm other services still use `REDIS_URL=redis://redis:6379`

## Testing
- `npm test` *(fails: Could not resolve workspaces; Missing `packageManager` field in package.json)*
- `npm run lint` *(fails: Could not resolve workspaces; Missing `packageManager` field in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dd4434bb88330ace78db6f923b1fe