### PR TITLE
docs: update host redis port to 6380

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ deploy: validate build ## Full deployment (validate, build, and start services)
 	@echo "- Direct Web App: http://localhost:3000"
 	@echo "- Direct ML API: http://localhost:3001"
 	@echo "- Qdrant: http://localhost:6333"
-	@echo "- Redis: localhost:6379"
+        @echo "- Redis: localhost:6380"
 
 quick-deploy: ## Quick deployment without rebuild
 	@echo -e "$(BLUE)[INFO]$(NC) Quick deployment (using existing images)..."
@@ -305,7 +305,7 @@ info: ## Show deployment information
 	@echo "- Direct Web App: http://localhost:3000"
 	@echo "- Direct ML API: http://localhost:3001"
 	@echo "- Qdrant: http://localhost:6333"
-	@echo "- Redis: localhost:6379"
+        @echo "- Redis: localhost:6380"
 	@echo ""
 	@echo "Available commands: make help"
 

--- a/PRODUCTION-DEPLOYMENT.md
+++ b/PRODUCTION-DEPLOYMENT.md
@@ -24,7 +24,7 @@ make deploy    # Deploy application
 - Ubuntu 20.04 LTS or later
 - Docker 20.10+ and Docker Compose v2
 - At least 4GB RAM and 20GB disk space
-- Open ports: 80, 443 (optional), 3000, 3001, 6333, 6379
+- Open ports: 80, 443 (optional), 3000, 3001, 6333, 6380
 
 ### Install Docker on Ubuntu
 

--- a/PRODUCTION-READY-SUMMARY.md
+++ b/PRODUCTION-READY-SUMMARY.md
@@ -11,7 +11,7 @@ The Aurum Miniapp is now **production-ready** and successfully deployed with all
 | **Web App** | ✅ Running | 3000 | http://localhost/api/health |
 | **ML API** | ✅ Running | 3001 | http://localhost/ml-api/api/health |
 | **Nginx** | ✅ Running | 80 | http://localhost/ |
-| **Redis** | ✅ Running | 6379 | Internal health checks |
+| **Redis** | ✅ Running | 6380 | Internal health checks |
 | **Qdrant** | ✅ Running | 6333 | Internal health checks |
 
 ## 🔧 Major Issues Fixed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ aurum-miniapp-prod/
 
 ### Infrastructure
 - **Nginx**: Reverse proxy and load balancer (Port 80)
-- **Redis**: Caching and session storage (Port 6379)
+- **Redis**: Caching and session storage (Port 6380)
 - **Qdrant**: Vector database for ML operations (Port 6333)
 
 ## Development
@@ -149,7 +149,7 @@ docker compose -f docker-compose.prod.yml logs -f nginx
 
 ### Common Issues
 
-1. **Port conflicts**: Check if ports 80, 3000, 3001, 6333, 6379 are available
+1. **Port conflicts**: Check if ports 80, 3000, 3001, 6333, 6380 are available
 2. **Docker permissions**: Ensure user is in docker group
 3. **SSL issues**: Verify certificate paths and nginx configuration
 

--- a/apps/ml-api/README.md
+++ b/apps/ml-api/README.md
@@ -55,9 +55,9 @@ NODE_ENV=development
 SERVICE_NAME=ml-api
 
 # Redis Configuration
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://localhost:6380
 REDIS_HOST=localhost
-REDIS_PORT=6379
+REDIS_PORT=6380
 REDIS_PASSWORD=
 REDIS_DB=0
 

--- a/apps/ml-api/src/config/index.ts
+++ b/apps/ml-api/src/config/index.ts
@@ -17,9 +17,9 @@ const envSchema = Joi.object({
   SERVICE_NAME: Joi.string().default('ml-api'),
 
   // Redis Configuration
-  REDIS_URL: Joi.string().default('redis://localhost:6379'),
+  REDIS_URL: Joi.string().default('redis://localhost:6380'),
   REDIS_HOST: Joi.string().default('localhost'),
-  REDIS_PORT: Joi.number().default(6379),
+  REDIS_PORT: Joi.number().default(6380),
   REDIS_PASSWORD: Joi.string().allow('').default(''),
   REDIS_DB: Joi.number().default(0),
 

--- a/apps/ml-api/src/services/queue.ts
+++ b/apps/ml-api/src/services/queue.ts
@@ -9,7 +9,7 @@ import { createRedisClient } from '../utils/redis';
 import { logger } from '@shared/utils';
 
 // Configuration
-const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6380';
 
 // Module state
 let redisClient: ReturnType<typeof createRedisClient> | null = null;

--- a/apps/ml-api/src/utils/redis.ts
+++ b/apps/ml-api/src/utils/redis.ts
@@ -7,7 +7,7 @@ export function createRedisClient(): RedisClientType {
 
   // Use localhost for local development, redis hostname for Docker
   const client: RedisClientType = createClient({
-    url: process.env.REDIS_URL || 'redis://localhost:6379',
+    url: process.env.REDIS_URL || 'redis://localhost:6380',
   });
 
   client.on('error', (err: Error) => {

--- a/deploy-production.sh
+++ b/deploy-production.sh
@@ -187,7 +187,7 @@ show_status() {
     echo "  - Web Application: http://localhost"
     echo "  - ML API: http://localhost/ml-api"
     echo "  - Nginx Health: http://localhost/nginx-health"
-    echo "  - Redis: localhost:6379"
+    echo "  - Redis: localhost:6380"
     echo "  - Qdrant: http://localhost:6333"
     echo ""
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -94,7 +94,7 @@ services:
   redis:
     image: redis:latest
     ports:
-      - "6379:6379" # Expose for direct access if needed
+      - "6380:6379" # Expose for direct access if needed
     volumes:
       - redis_data:/data
     restart: unless-stopped

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -106,7 +106,7 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379" # Expose for direct access if needed
+      - "6380:6379" # Expose for direct access if needed
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes

--- a/validate-deployment.sh
+++ b/validate-deployment.sh
@@ -150,7 +150,7 @@ print_success "Nginx configuration files exist and will be validated during depl
 
 # Check port availability
 print_status "Checking port availability..."
-ports=(80 3000 3001 6333 6379)
+ports=(80 3000 3001 6333 6380)
 for port in "${ports[@]}"; do
     if netstat -tuln 2>/dev/null | grep -q ":$port "; then
         print_warning "Port $port is already in use"


### PR DESCRIPTION
## Summary
- update host Redis port references to 6380 across docs and scripts
- adjust docker compose and ML API defaults for new Redis port

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd4461a8483308fa2f675afde3d46