### PR TITLE
chore: update ml-api Redis default port to 6380

### DIFF
--- a/apps/ml-api/README.md
+++ b/apps/ml-api/README.md
@@ -55,9 +55,9 @@ NODE_ENV=development
 SERVICE_NAME=ml-api
 
 # Redis Configuration
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://localhost:6380
 REDIS_HOST=localhost
-REDIS_PORT=6379
+REDIS_PORT=6380
 REDIS_PASSWORD=
 REDIS_DB=0
 

--- a/apps/ml-api/src/config/index.ts
+++ b/apps/ml-api/src/config/index.ts
@@ -17,9 +17,9 @@ const envSchema = Joi.object({
   SERVICE_NAME: Joi.string().default('ml-api'),
 
   // Redis Configuration
-  REDIS_URL: Joi.string().default('redis://localhost:6379'),
+  REDIS_URL: Joi.string().default('redis://localhost:6380'),
   REDIS_HOST: Joi.string().default('localhost'),
-  REDIS_PORT: Joi.number().default(6379),
+  REDIS_PORT: Joi.number().default(6380),
   REDIS_PASSWORD: Joi.string().allow('').default(''),
   REDIS_DB: Joi.number().default(0),
 

--- a/apps/ml-api/src/services/queue.ts
+++ b/apps/ml-api/src/services/queue.ts
@@ -9,7 +9,7 @@ import { createRedisClient } from '../utils/redis';
 import { logger } from '@shared/utils';
 
 // Configuration
-const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6380';
 
 // Module state
 let redisClient: ReturnType<typeof createRedisClient> | null = null;

--- a/apps/ml-api/src/utils/redis.ts
+++ b/apps/ml-api/src/utils/redis.ts
@@ -3,11 +3,11 @@ import { logger } from '@shared/utils';
 
 export function createRedisClient(): RedisClientType {
   // [DEPRECATED: 2025-08-11] Docker hostname preserved for reference
-  // url: process.env.REDIS_URL || "redis://redis:6379",
+  // url: process.env.REDIS_URL || "redis://redis:6380",
 
   // Use localhost for local development, redis hostname for Docker
   const client: RedisClientType = createClient({
-    url: process.env.REDIS_URL || 'redis://localhost:6379',
+    url: process.env.REDIS_URL || 'redis://localhost:6380',
   });
 
   client.on('error', (err: Error) => {


### PR DESCRIPTION
## Summary
- use Redis port 6380 by default in queue service and Redis helper
- set default REDIS_URL and REDIS_PORT to 6380 in ML API config
- update README examples with new Redis port

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689dd446b25c83308af8bb1260c121fc